### PR TITLE
Add to list of known working dehumidifiers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ This means an alternative is to hook up directly to this serial interface and by
 ## Compatibility list
 This list contains all tested and known-working dehumidifiers:
 
+* Midea MAD22S1WWT
 * Comfee MDDF-20DEN7-WF
 * Inventor Eva II PRO WI-FI
 


### PR DESCRIPTION
I bought the Midea 22 pint (MAD22S1WWT) dehumidifier with the intention to use this repo. It appears to be working well!

https://www.midea.com/us/Air-Conditioners/Dehumidifiers/22-Pint-Smartdry-Dehumidifier-MAD22S1WWT

Listening to topic:
`esp8266-midea-dehumidifier/DEHUMIDIFIER-[redacted]/state`

I receive:
```
{
    "state": "on",
    "humiditySetpoint": 35,
    "humidityCurrent": 38,
    "errorCode": 0,
    "fanSpeed": "high",
    "mode": "setpoint",
    "wifi": {
        "ssid": "[redacted]",
        "ip": "[redacted]",
        "rssi": -55
    }
}
```

I also updated `humiditySetpoint` using the `command` example in the readme and that also appears to work.

I'm guessing that's enough for now to say this model is supported?

Thanks for putting this repo together!